### PR TITLE
Add playback mode selection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,7 @@ on:
     branches: ['main']
 
 env:
-  NEXT_PUBLIC_POSTHOG_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST }}
-  NEXT_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+  SKIP_ENV_VALIDATION: 1
 
 jobs:
   checks:

--- a/app/components/result-stage.tsx
+++ b/app/components/result-stage.tsx
@@ -31,9 +31,12 @@ const versionOptions: Record<Version, string> = {
 }
 
 const playbackModeOptions: Record<PlaybackMode, [string, string]> = {
-  'global': ['Global' ,'The song can be heard everywhere'],
-  'surface': ['Surface', 'The song can be heard on speaker\'s surface'],
-  'local': ['Local', 'The song can be heard within the audible range around the speaker'],
+  global: ['Global', 'The song plays everywhere'],
+  surface: ['Surface', "The song plays on the speakers' surface"],
+  local: [
+    'Local - not recommended for large songs',
+    'The song plays where the speakers are. With many speakers, this could cause an uneven mix.',
+  ],
 }
 
 export type ResultStageProps = {
@@ -52,7 +55,11 @@ export const ResultStage = ({ song }: ResultStageProps) => {
     setCopySuccess(false)
     const signalSet = targetVersion === '2SA' ? signalsDlc : signals
 
-    const { blueprint, warnings } = songToFactorio(song, signalSet, playbackMode)
+    const { blueprint, warnings } = songToFactorio(
+      song,
+      signalSet,
+      playbackMode,
+    )
     const copyAttempt = await copyToClipboard(blueprint)
     setWarnings(warnings)
     setCopySuccess(copyAttempt)

--- a/app/lib/blueprint/blueprint.ts
+++ b/app/lib/blueprint/blueprint.ts
@@ -1,6 +1,6 @@
 import { encodeBlueprint } from '@/app/lib/utils'
 import { Speakers } from '@/app/lib/song-to-factorio'
-import { Entity, Wire } from '@/app/lib/factorio-blueprint-schema'
+import { Entity, PlaybackMode, Wire } from '@/app/lib/factorio-blueprint-schema'
 import { getSpeakerSection } from '@/app/lib/blueprint/speaker-section'
 import { getStaticBlueprintSection } from '@/app/lib/blueprint/static-blueprint-section'
 import { getDataSection } from '@/app/lib/blueprint/data-section'
@@ -60,11 +60,13 @@ export const toBlueprint = ({
   combinatorValues,
   speakers,
   rawSignals,
+  playbackMode,
 }: {
   song: Song
   combinatorValues: CombinatorValuePair[]
   speakers: Speakers
   rawSignals: RawSignal[]
+  playbackMode: PlaybackMode
 }): BlueprintResult => {
   const warnings = []
   const signals = prepareSignals(rawSignals)
@@ -86,7 +88,7 @@ export const toBlueprint = ({
       firstSpeakerCombinatorEntity,
       secondSpeakerCombinatorEntity,
     },
-  } = getSpeakerSection(0, { speakers })
+  } = getSpeakerSection(0, { speakers, playbackMode })
   const {
     blueprintSection: staticBlueprintSection,
     keyEntities: { playCombinatorEntity, dataToArithmeticConnectionEntity },

--- a/app/lib/blueprint/speaker-section.ts
+++ b/app/lib/blueprint/speaker-section.ts
@@ -19,7 +19,7 @@ export const getSpeakerSection = (
   const en = localEntityNumberToAbsolute(entitiesSoFar)
 
   Object.values(speakers).forEach(
-    ({ instrumentName, volume }, speakerIndex) => {
+    ({ instrumentName, volume, playbackMode }, speakerIndex) => {
       const instrument = getFactorioInstrument(instrumentName)
       const speakerEntity = en(speakerIndex * 2 + 1)
       const speakerCombinatorEntity = en(speakerIndex * 2 + 2)
@@ -49,7 +49,7 @@ export const getSpeakerSection = (
           },
           parameters: {
             playback_volume: instrument.volumeCorrection * volume,
-            playback_mode: 'global',
+            playback_mode: playbackMode,
             allow_polyphony: true,
           },
         },

--- a/app/lib/blueprint/speaker-section.ts
+++ b/app/lib/blueprint/speaker-section.ts
@@ -1,11 +1,17 @@
 import { BlueprintSection } from '@/app/lib/blueprint/blueprint'
 import { Speakers } from '@/app/lib/song-to-factorio'
-import { Entity, Wire } from '@/app/lib/factorio-blueprint-schema'
+import { Entity, PlaybackMode, Wire } from '@/app/lib/factorio-blueprint-schema'
 import { localEntityNumberToAbsolute } from '@/app/lib/utils'
 import { getFactorioInstrument } from '@/app/lib/factorio-instrument'
 export const getSpeakerSection = (
   entitiesSoFar: number,
-  { speakers }: { speakers: Speakers },
+  {
+    speakers,
+    playbackMode,
+  }: {
+    speakers: Speakers
+    playbackMode: PlaybackMode
+  },
 ): {
   keyEntities: {
     firstSpeakerCombinatorEntity: number
@@ -19,7 +25,7 @@ export const getSpeakerSection = (
   const en = localEntityNumberToAbsolute(entitiesSoFar)
 
   Object.values(speakers).forEach(
-    ({ instrumentName, volume, playbackMode }, speakerIndex) => {
+    ({ instrumentName, volume }, speakerIndex) => {
       const instrument = getFactorioInstrument(instrumentName)
       const speakerEntity = en(speakerIndex * 2 + 1)
       const speakerCombinatorEntity = en(speakerIndex * 2 + 2)

--- a/app/lib/factorio-blueprint-schema.ts
+++ b/app/lib/factorio-blueprint-schema.ts
@@ -30,7 +30,7 @@ export type Networks = {
   green: boolean
 }
 
-export type PlaybackMode = 'surface' | 'global'
+export type PlaybackMode = 'local' | 'surface' | 'global'
 
 export type Entity = {
   entity_number: number

--- a/app/lib/song-to-factorio.test.ts
+++ b/app/lib/song-to-factorio.test.ts
@@ -48,7 +48,7 @@ describe('Song to Blueprint', async () => {
         const processedSong = midiToSong(song, testFile)
 
         expect(
-          songToFactorio(processedSong, signals).blueprint,
+          songToFactorio(processedSong, signals, 'global').blueprint,
         ).toMatchSnapshot()
       },
     )

--- a/app/lib/song-to-factorio.ts
+++ b/app/lib/song-to-factorio.ts
@@ -8,6 +8,7 @@ import { roundToNearestClusterCenter } from '@/app/lib/kmeans'
 import groupBy from 'lodash.groupby'
 import { FactorioInstrumentName } from '@/app/lib/data/factorio-instruments-by-id'
 import { noteToFactorioNote, Song } from '@/app/lib/song'
+import { PlaybackMode } from './factorio-blueprint-schema'
 
 type FactorioNote = number
 type Chord = FactorioNote[]
@@ -22,10 +23,11 @@ export type Speakers = Record<
     chords: Chord[]
     instrumentName: FactorioInstrumentName
     volume: number
+    playbackMode: PlaybackMode
   }
 >
 
-export const songToFactorioData = ({ midi, settings }: Song): Speakers => {
+export const songToFactorioData = ({ midi, settings }: Song, playbackMode: PlaybackMode): Speakers => {
   const instrumentsAfterVelocity: Speakers = {}
 
   for (const trackNumber in midi.tracks) {
@@ -54,6 +56,7 @@ export const songToFactorioData = ({ midi, settings }: Song): Speakers => {
             chords: [],
             instrumentName,
             volume,
+            playbackMode,
           }
         }
 
@@ -83,8 +86,9 @@ export const songToFactorioData = ({ midi, settings }: Song): Speakers => {
 export const songToFactorio = (
   song: Song,
   signals: RawSignal[],
+  playbackMode: PlaybackMode
 ): BlueprintResult => {
-  const instruments = songToFactorioData(song)
+  const instruments = songToFactorioData(song, playbackMode)
 
   type Event = {
     time: number

--- a/app/lib/song-to-factorio.ts
+++ b/app/lib/song-to-factorio.ts
@@ -23,11 +23,10 @@ export type Speakers = Record<
     chords: Chord[]
     instrumentName: FactorioInstrumentName
     volume: number
-    playbackMode: PlaybackMode
   }
 >
 
-export const songToFactorioData = ({ midi, settings }: Song, playbackMode: PlaybackMode): Speakers => {
+export const songToFactorioData = ({ midi, settings }: Song): Speakers => {
   const instrumentsAfterVelocity: Speakers = {}
 
   for (const trackNumber in midi.tracks) {
@@ -56,7 +55,6 @@ export const songToFactorioData = ({ midi, settings }: Song, playbackMode: Playb
             chords: [],
             instrumentName,
             volume,
-            playbackMode,
           }
         }
 
@@ -86,9 +84,9 @@ export const songToFactorioData = ({ midi, settings }: Song, playbackMode: Playb
 export const songToFactorio = (
   song: Song,
   signals: RawSignal[],
-  playbackMode: PlaybackMode
+  playbackMode: PlaybackMode,
 ): BlueprintResult => {
-  const instruments = songToFactorioData(song, playbackMode)
+  const instruments = songToFactorioData(song)
 
   type Event = {
     time: number
@@ -164,5 +162,6 @@ export const songToFactorio = (
     combinatorValues,
     speakers: instrumentsAfterChords,
     rawSignals: signals,
+    playbackMode,
   })
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miditorio",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "license": "AGPL-3.0-or-later",
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Playback mode selection to the Blueprint page. Tested on Factorio 2.0.32 Space Age.

![kuva](https://github.com/user-attachments/assets/a8239283-a7c5-4480-beee-5625783ab8d4)

closes #3 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a playback mode option in the results view, allowing users to choose among “global,” “surface,” and “local” modes.
  - Blueprint generation now adapts its output based on the selected playback mode, enhancing customization and flexibility.
  
- **Chores**
  - Updated the version of the "miditorio" package from "2.1.4" to "2.2.0".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->